### PR TITLE
vlc.js: pass volume changes using proper locale

### DIFF
--- a/src/js/src/vlc.js
+++ b/src/js/src/vlc.js
@@ -43,11 +43,11 @@ var VLC = {
 				break;
 			case REQUEST.VOLUME_INCREMENT:
 				params.command = 'volume';
-				params.val = '+12.8';
+				params.val = '+'+(12.8).toLocaleString();
 				break;
 			case REQUEST.VOLUME_DECREMENT:
 				params.command = 'volume';
-				params.val = '-12.8';
+				params.val = (-12.8).toLocaleString();
 				break;
 			case REQUEST.VOLUME_MIN:
 				params.command = 'volume';


### PR DESCRIPTION
This fixes issue #23. However, as written that bug, it's probably to avoid passing double values (phone and VLC locale might be different), and ceil this value to 13.
